### PR TITLE
Change how `aot` compile options are applied

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -44,6 +44,7 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
+              "aot": true,
               "budgets": [
                 {
                   "type": "initial",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --aot=true",
+    "start": "ng serve",
     "build": "ng build --output-path dist/client",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
**Description**
Extracted by settings without specifying options in npm script

**Describe the solution you'd like A clear and concise description of what you want to happen.**
You can set the `aot` compilation option for `angular.json`

**Additional context Add any other context or screenshots about the feature request here.**
N/A